### PR TITLE
Remove createJSModules from RNShopifyPackage.java

### DIFF
--- a/android/src/main/java/com/reactnativeshopify/RNShopifyPackage.java
+++ b/android/src/main/java/com/reactnativeshopify/RNShopifyPackage.java
@@ -17,11 +17,6 @@ public class RNShopifyPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }


### PR DESCRIPTION
If applied this commit will prune the `createJSModules` function from `RNShopifyPackage`

* Partially solves https://github.com/aiincorporated/bobMobileAppAndroid/issues/1240
* Related to https://github.com/aiincorporated/bobMobileAppAndroid/issues/1237

### Changes

* `createJSModules` function  in the base class is deprecated or removed so we cannot override this method any more.